### PR TITLE
[docs] Update expo install command to use `npx expo install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ yarn add react-native-squircle
 For expo:
 
 ```sh
-expo install react-native-squircle
+npx expo install react-native-squircle
 ```
 
 ## Example


### PR DESCRIPTION
Hi 👋 

found your tweet about this library! Great job 🎉 

One thing I'd like to update and make it future proof for Expo specific projects is to update the installation command from `expo install...` to `npx expo install...`. Since the latter referees to the new [Expo CLI](https://docs.expo.dev/more/expo-cli/), which doesn't require any global package installation. For `expo install`, people will need to install the deprecated global cli (and we are not recommending that).

Thank you!